### PR TITLE
[FEAT] Implement shooting mechanics for gun turret and sniper tower

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -18,6 +18,10 @@ config/icon="res://icon.svg"
 
 ResourceManager="*res://scripts/managers/resource_manager.gd"
 
+[global_group]
+
+enemies=""
+
 [rendering]
 
 textures/canvas_textures/default_texture_filter=0

--- a/scenes/Towers/GunTurret/bullet_red.tscn
+++ b/scenes/Towers/GunTurret/bullet_red.tscn
@@ -1,15 +1,18 @@
-[gd_scene load_steps=3 format=3 uid="uid://cjmcp3atom5c8"]
+[gd_scene load_steps=4 format=3 uid="uid://cjmcp3atom5c8"]
 
 [ext_resource type="Texture2D" uid="uid://d8ol186cbcun" path="res://assets/towers/gun-turret/Bullet-Red.png" id="1_g7rx7"]
+[ext_resource type="Script" path="res://scripts/towers/bullet.gd" id="1_sr80s"]
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_5m8pp"]
 size = Vector2(23, 8)
 
 [node name="BulletRed" type="CharacterBody2D"]
+script = ExtResource("1_sr80s")
 
 [node name="Sprite2D" type="Sprite2D" parent="."]
 texture = ExtResource("1_g7rx7")
+offset = Vector2(-10, 0)
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]
-position = Vector2(0.5, 0)
+position = Vector2(-9.5, 0)
 shape = SubResource("RectangleShape2D_5m8pp")

--- a/scenes/Towers/GunTurret/gun_turret.tscn
+++ b/scenes/Towers/GunTurret/gun_turret.tscn
@@ -1,6 +1,8 @@
-[gd_scene load_steps=9 format=3 uid="uid://d2in52y6ycisl"]
+[gd_scene load_steps=12 format=3 uid="uid://d2in52y6ycisl"]
 
+[ext_resource type="Script" path="res://scripts/towers/attack_tower.gd" id="1_7cibg"]
 [ext_resource type="Texture2D" uid="uid://bdq214k1dfden" path="res://assets/towers/gun-turret/Gun-Turret-1.png" id="1_y2kio"]
+[ext_resource type="PackedScene" uid="uid://cjmcp3atom5c8" path="res://scenes/Towers/GunTurret/bullet_red.tscn" id="2_wanj0"]
 
 [sub_resource type="AtlasTexture" id="AtlasTexture_c54au"]
 atlas = ExtResource("1_y2kio")
@@ -53,7 +55,15 @@ animations = [{
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_wcaos"]
 size = Vector2(42, 29)
 
+[sub_resource type="CircleShape2D" id="CircleShape2D_bgwk7"]
+radius = 120.0
+
 [node name="GunTurret" type="StaticBody2D"]
+script = ExtResource("1_7cibg")
+bullet_scene = ExtResource("2_wanj0")
+
+[node name="Aim" type="Marker2D" parent="."]
+position = Vector2(30, -5)
 
 [node name="AnimatedSprite2D" type="AnimatedSprite2D" parent="."]
 sprite_frames = SubResource("SpriteFrames_edxmu")
@@ -62,3 +72,14 @@ animation = &"nembak"
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]
 position = Vector2(0, 4.5)
 shape = SubResource("RectangleShape2D_wcaos")
+
+[node name="Sight" type="Area2D" parent="."]
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="Sight"]
+shape = SubResource("CircleShape2D_bgwk7")
+
+[node name="CooldownTimer" type="Timer" parent="."]
+
+[connection signal="body_entered" from="Sight" to="." method="_on_detection_area_body_entered"]
+[connection signal="body_exited" from="Sight" to="." method="_on_detection_area_body_exited"]
+[connection signal="timeout" from="CooldownTimer" to="." method="_on_cooldown_timer_timeout"]

--- a/scenes/Towers/SniperTower/bullet_green.tscn
+++ b/scenes/Towers/SniperTower/bullet_green.tscn
@@ -1,15 +1,18 @@
-[gd_scene load_steps=3 format=3 uid="uid://dmcw8gn0qrjpj"]
+[gd_scene load_steps=4 format=3 uid="uid://dmcw8gn0qrjpj"]
 
+[ext_resource type="Script" path="res://scripts/towers/bullet.gd" id="1_51044"]
 [ext_resource type="Texture2D" uid="uid://csbueq8tsjd6u" path="res://assets/towers/sniper-tower/Bullet-Green.png" id="1_vrnb0"]
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_wj8m8"]
 size = Vector2(23, 8)
 
 [node name="BulletGreen" type="CharacterBody2D"]
+script = ExtResource("1_51044")
 
 [node name="Sprite2D" type="Sprite2D" parent="."]
 texture = ExtResource("1_vrnb0")
+offset = Vector2(-10, 0)
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]
-position = Vector2(0.5, 0)
+position = Vector2(-9.5, 0)
 shape = SubResource("RectangleShape2D_wj8m8")

--- a/scenes/Towers/SniperTower/sniper_tower.tscn
+++ b/scenes/Towers/SniperTower/sniper_tower.tscn
@@ -1,6 +1,8 @@
-[gd_scene load_steps=5 format=3 uid="uid://dmkx14uyeu3s1"]
+[gd_scene load_steps=8 format=3 uid="uid://dmkx14uyeu3s1"]
 
 [ext_resource type="Texture2D" uid="uid://dsj4dqmrj2avu" path="res://assets/towers/sniper-tower/Sniper-Tower.png" id="1_5tetq"]
+[ext_resource type="Script" path="res://scripts/towers/attack_tower.gd" id="1_rvifk"]
+[ext_resource type="PackedScene" uid="uid://dmcw8gn0qrjpj" path="res://scenes/Towers/SniperTower/bullet_green.tscn" id="2_2c465"]
 
 [sub_resource type="AtlasTexture" id="AtlasTexture_hwhal"]
 atlas = ExtResource("1_5tetq")
@@ -20,7 +22,23 @@ animations = [{
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_ga5v3"]
 size = Vector2(22.5, 39)
 
+[sub_resource type="CircleShape2D" id="CircleShape2D_bkpds"]
+radius = 250.0
+
 [node name="SniperTower" type="StaticBody2D"]
+script = ExtResource("1_rvifk")
+bullet_scene = ExtResource("2_2c465")
+base_bullet_speed = 1000.0
+base_bullet_damage = 3.0
+base_attack_range = 200.0
+base_reload_time = 3.0
+range_upgrade_add = 20.0
+damage_upgrade_add = 3.0
+reload_upgrade_reduce = 0.2
+upgrade_cost_base = 75
+
+[node name="Aim" type="Marker2D" parent="."]
+position = Vector2(30, -12)
 
 [node name="AnimatedSprite2D" type="AnimatedSprite2D" parent="."]
 sprite_frames = SubResource("SpriteFrames_mtbu0")
@@ -28,3 +46,14 @@ sprite_frames = SubResource("SpriteFrames_mtbu0")
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]
 position = Vector2(-0.75, 10.5)
 shape = SubResource("RectangleShape2D_ga5v3")
+
+[node name="Sight" type="Area2D" parent="."]
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="Sight"]
+shape = SubResource("CircleShape2D_bkpds")
+
+[node name="CooldownTimer" type="Timer" parent="."]
+
+[connection signal="body_entered" from="Sight" to="." method="_on_detection_area_body_entered"]
+[connection signal="body_exited" from="Sight" to="." method="_on_detection_area_body_exited"]
+[connection signal="timeout" from="CooldownTimer" to="." method="_on_cooldown_timer_timeout"]

--- a/scripts/towers/attack_tower.gd
+++ b/scripts/towers/attack_tower.gd
@@ -1,0 +1,133 @@
+extends BaseTower
+class_name AttackTower
+
+# Combat properties
+@export var bullet_scene: PackedScene
+@export var base_bullet_speed: float = 500
+@export var base_bullet_damage: float = 1
+@export var base_attack_range: float = 120
+@export var base_reload_time: float = 1.0
+
+# Simplified upgrade parameters
+@export var range_upgrade_add: float = 15    # +15 increase per level
+@export var damage_upgrade_add: float = 2        # +2 damage per level
+@export var reload_upgrade_reduce: float = 0.1   # -0.1s per level
+@export var upgrade_cost_base: int = 50          # Cost increases by 75 each level
+
+# Runtime arrays (auto-generated)
+var range_additions: Array[float] = []
+var damage_additions: Array[float] = []
+var reload_reductions: Array[float] = []
+var upgrade_costs: Array[int] = []
+
+# Current stats
+var current_bullet_speed: float
+var current_bullet_damage: float
+var current_attack_range: float
+var current_reload_time: float
+
+var enemies_in_range: Array = []
+var current_target: Node2D = null
+
+@onready var aim: Marker2D = $Aim
+@onready var detection_area: Area2D = $Sight
+@onready var cooldown_timer: Timer = $CooldownTimer
+
+func _ready():
+	super._ready()
+	_build_upgrade_arrays()
+	initialize_stats()
+	update_detection_area()
+
+func _build_upgrade_arrays():
+	range_additions = [0.0]
+	damage_additions = [0.0]
+	reload_reductions = [0.0]
+	upgrade_costs = []
+	
+	for level in range(1, max_level + 1):
+		# Range: linear addition (0, +15, +30)
+		range_additions.append(range_upgrade_add * level)
+		
+		# Damage: linear addition (0, +2, +4)
+		damage_additions.append(damage_upgrade_add * level)
+		
+		# Reload: linear reduction (0, -0.1, -0.2)
+		reload_reductions.append(reload_upgrade_reduce * level)
+		
+		# Costs: linear increase (75, 150)
+		upgrade_costs.append(upgrade_cost_base * level)
+	
+func initialize_stats():
+	current_bullet_speed = base_bullet_speed
+	current_bullet_damage = base_bullet_damage
+	current_attack_range = base_attack_range
+	current_reload_time = base_reload_time
+	cooldown_timer.wait_time = current_reload_time
+
+func update_detection_area():
+	var collision_shape = detection_area.get_node("CollisionShape2D")
+	var circle_shape = collision_shape.shape as CircleShape2D
+	circle_shape.radius = current_attack_range
+
+func _process(delta):
+	if not is_active:
+		return
+	
+	enemies_in_range = enemies_in_range.filter(func(enemy): 
+		return is_instance_valid(enemy) and enemy.is_inside_tree()
+	)
+	
+	if enemies_in_range.size() > 0:
+		# Find enemy furthest along the path
+		enemies_in_range.sort_custom(func(a, b): 
+			return a.get_parent().progress > b.get_parent().progress
+		)
+		current_target = enemies_in_range[0]
+		
+		if cooldown_timer.is_stopped():
+			shoot()
+			cooldown_timer.start()
+	else:
+		current_target = null
+
+func shoot():
+	if not bullet_scene or not current_target:
+		return
+	
+	var bullet = bullet_scene.instantiate()
+	var spawn_pos = aim.global_position
+	get_parent().add_child(bullet)
+	bullet.global_position = spawn_pos
+	bullet.setup(
+		current_target,
+		current_bullet_damage,
+		current_bullet_speed,
+		spawn_pos
+	)
+
+func _on_detection_area_body_entered(body):
+	if body.is_in_group("enemies") and is_active:
+		enemies_in_range.append(body)
+
+func _on_detection_area_body_exited(body):
+	if body in enemies_in_range:
+		enemies_in_range.erase(body)
+
+# Upgrade implementation
+func get_upgrade_cost() -> int:
+	if tower_level <= max_level:
+		return upgrade_costs[tower_level - 1]
+	return 0
+
+func update_tower_stats():
+	current_attack_range = base_attack_range + range_additions[tower_level - 1]
+	current_bullet_damage = base_bullet_damage + damage_additions[tower_level - 1]
+	current_reload_time = base_reload_time - reload_reductions[tower_level - 1]
+	
+	# Update components
+	update_detection_area()
+	cooldown_timer.wait_time = current_reload_time
+
+func _on_cooldown_timer_timeout():
+	cooldown_timer.stop()

--- a/scripts/towers/bullet.gd
+++ b/scripts/towers/bullet.gd
@@ -1,0 +1,39 @@
+extends CharacterBody2D
+
+var damage: float
+var speed: float
+var target: Node2D
+var start_position: Vector2
+
+func setup(target_node: Node2D, bullet_damage: float, bullet_speed: float, spawn_position: Vector2):
+	target = target_node
+	damage = bullet_damage
+	speed = bullet_speed
+	global_position = spawn_position
+	start_position = spawn_position
+
+func _physics_process(delta):
+	if not is_instance_valid(target) or !target.is_inside_tree():
+		# If target is gone, continue in last known direction
+		velocity = velocity.normalized() * speed
+	else:
+		var target_position = target.global_position
+		velocity = global_position.direction_to(target_position) * speed
+		look_at(target_position)
+	
+	move_and_slide()
+	
+	# Check for collisions or distance traveled
+	if check_collisions() || global_position.distance_to(start_position) > 1000:
+		queue_free()
+
+func check_collisions():
+	for i in get_slide_collision_count():
+		var collision = get_slide_collision(i)
+		var collider = collision.get_collider()
+		if collider.is_in_group("enemies"):
+			if collider.has_method("take_damage"):
+				collider.take_damage(damage)
+			queue_free()
+			return true
+	return false


### PR DESCRIPTION
# Implement shooting mechanics for gun turret and sniper tower 

## Summary
- Create scripts for gun turret and sniper tower named `attack_tower.gd` that is customizable and for red bullet and green bullet named `bullet.gd`.
- Add `Area2D` (Sight) node for detecting enemies, `Marker2D` (Aim), and `Timer` (CooldownTimer) node in both tower scenes to implement the shooting mechanism integrated by the script.

## Next Steps
- Can implement collision layer/mask
- Wait for enemies implementation to test the actual shooting mechanics
- Implement upgrade feature for towers